### PR TITLE
chore: refactor test helper function for HTTP API tests

### DIFF
--- a/internal/checks/kube/resources.go
+++ b/internal/checks/kube/resources.go
@@ -1,1 +1,12 @@
 package kube
+
+import (
+	"context"
+
+	"github.com/cdr/coder-doctor/internal/api"
+)
+
+func (k *KubernetesChecker) CheckResources(ctx context.Context) []*api.CheckResult {
+	results := make([]*api.CheckResult, 0)
+	return results
+}

--- a/internal/checks/kube/util_test.go
+++ b/internal/checks/kube/util_test.go
@@ -1,0 +1,22 @@
+package kube
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cdr.dev/slog/sloggers/slogtest/assert"
+)
+
+// newTestHTTPServer creates a HTTP server that just returns the given status code and response.
+func newTestHTTPServer(t *testing.T, statusCode int, resp interface{}) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		err := json.NewEncoder(w).Encode(resp)
+		assert.Success(t, "failed to encode response", err)
+	}))
+	return srv
+}


### PR DESCRIPTION
There was a bit of repeated code in the unit tests that can be refactored into a helper function.