### PR TITLE
internal/checks/kube: add more API resource requirements

### DIFF
--- a/internal/checks/kube/kubernetes.go
+++ b/internal/checks/kube/kubernetes.go
@@ -17,12 +17,12 @@ import (
 var _ = api.Checker(&KubernetesChecker{})
 
 type KubernetesChecker struct {
-	namespace        string
-	client           kubernetes.Interface
-	writer           api.ResultWriter
-	coderVersion     *semver.Version
-	log              slog.Logger
-	rbacRequirements map[*ResourceRequirement]ResourceVerbs
+	namespace    string
+	client       kubernetes.Interface
+	writer       api.ResultWriter
+	coderVersion *semver.Version
+	log          slog.Logger
+	reqs         *VersionedResourceRequirements
 }
 
 type Option func(k *KubernetesChecker)
@@ -41,7 +41,7 @@ func NewKubernetesChecker(client kubernetes.Interface, opts ...Option) *Kubernet
 		opt(checker)
 	}
 
-	checker.rbacRequirements = findClosestVersionRequirements(checker.coderVersion)
+	checker.reqs = findClosestVersionRequirements(checker.coderVersion)
 
 	if err := checker.Validate(); err != nil {
 		panic(xerrors.Errorf("error validating kube checker: %w", err))
@@ -75,7 +75,7 @@ func WithNamespace(ns string) Option {
 }
 
 func (k *KubernetesChecker) Validate() error {
-	if k.rbacRequirements == nil {
+	if k.reqs == nil {
 		return xerrors.Errorf("unhandled coder version: %s", k.coderVersion.String())
 	}
 	return nil

--- a/internal/checks/kube/resources.go
+++ b/internal/checks/kube/resources.go
@@ -45,8 +45,7 @@ func (k *KubernetesChecker) CheckResources(_ context.Context) []*api.CheckResult
 		}
 	}
 
-	versionReqs := findClosestVersionRequirements(k.coderVersion)
-	for versionReq := range versionReqs {
+	for versionReq := range k.reqs.ResourceRequirements {
 		if !resourcesAvailable[*versionReq] {
 			msg := fmt.Sprintf("missing required resource:%q group:%q version:%q", versionReq.Resource, versionReq.Group, versionReq.Version)
 			errResult := api.ErrorResult(checkName, msg, xerrors.New(msg))

--- a/internal/checks/kube/resources_list.go
+++ b/internal/checks/kube/resources_list.go
@@ -6,20 +6,53 @@ import (
 	"github.com/cdr/coder-doctor/internal/api"
 )
 
+// This is a list of all known Resource and/or RBAC requirements for each verison of Coder.
+// Order by version DESCENDING.
 var allRequirements = []VersionedResourceRequirements{
 	{
 		VersionConstraints: api.MustConstraint(">= 1.20"),
 		ResourceRequirements: map[*ResourceRequirement]ResourceVerbs{
-			NewResourceRequirement("", "v1", "pods"):                                                            verbsCreateDeleteList,
-			NewResourceRequirement("", "v1", "secrets"):                                                         verbsCreateDeleteList,
-			NewResourceRequirement("", "v1", "serviceaccounts"):                                                 verbsCreateDeleteList,
-			NewResourceRequirement("", "v1", "services"):                                                        verbsCreateDeleteList,
-			NewResourceRequirement("apps", "apps/v1", "deployments"):                                            verbsCreateDeleteList,
-			NewResourceRequirement("apps", "apps/v1", "replicasets"):                                            verbsCreateDeleteList,
-			NewResourceRequirement("apps", "apps/v1", "statefulsets"):                                           verbsCreateDeleteList,
-			NewResourceRequirement("networking.k8s.io", "networking.k8s.io/v1", "ingresses"):                    verbsCreateDeleteList,
-			NewResourceRequirement("rbac.authorization.k8s.io", "rbac.authorization.k8s.io/v1", "roles"):        verbsCreateDeleteList,
-			NewResourceRequirement("rbac.authorization.k8s.io", "rbac.authorization.k8s.io/v1", "rolebindings"): verbsCreateDeleteList,
+			NewResourceRequirement("", "v1", "events"):                                                          verbsAll,
+			NewResourceRequirement("", "v1", "persistentvolumeclaims"):                                          verbsAll,
+			NewResourceRequirement("", "v1", "pods"):                                                            verbsAll,
+			NewResourceRequirement("", "v1", "secrets"):                                                         verbsAll,
+			NewResourceRequirement("", "v1", "serviceaccounts"):                                                 verbsAll,
+			NewResourceRequirement("", "v1", "services"):                                                        verbsAll,
+			NewResourceRequirement("apps", "apps/v1", "deployments"):                                            verbsAll,
+			NewResourceRequirement("apps", "apps/v1", "replicasets"):                                            verbsAll,
+			NewResourceRequirement("apps", "apps/v1", "statefulsets"):                                           verbsAll,
+			NewResourceRequirement("metrics.k8s.io", "metrics.k8s.io/v1beta1", "pods"):                          verbsGetListWatch,
+			NewResourceRequirement("networking.k8s.io", "networking.k8s.io/v1", "ingresses"):                    verbsAll,
+			NewResourceRequirement("networking.k8s.io", "networking.k8s.io/v1", "networkpolicies"):              verbsAll,
+			NewResourceRequirement("rbac.authorization.k8s.io", "rbac.authorization.k8s.io/v1", "roles"):        verbsGetCreate,
+			NewResourceRequirement("rbac.authorization.k8s.io", "rbac.authorization.k8s.io/v1", "rolebindings"): verbsGetCreate,
+			NewResourceRequirement("storage.k8s.io", "storage.k8s.io/v1", "storageclasses"):                     verbsGetListWatch,
+		},
+		RoleOnlyResourceRequirements: map[*ResourceRequirement]ResourceVerbs{
+			// The below permissions are required by the default coder role created by the Helm chart.
+			// Installation will fail if these are not present in the role being used to install Coder.
+			NewResourceRequirement("", "v1", "deployments"):                             verbsAll,
+			NewResourceRequirement("", "v1", "networkpolicies"):                         verbsAll,
+			NewResourceRequirement("", "v1", "pods/exec"):                               verbsAll,
+			NewResourceRequirement("", "v1", "pods/log"):                                verbsAll,
+			NewResourceRequirement("apps", "v1", "events"):                              verbsAll,
+			NewResourceRequirement("apps", "v1", "networkpolicies"):                     verbsAll,
+			NewResourceRequirement("apps", "v1", "persistentvolumeclaims"):              verbsAll,
+			NewResourceRequirement("apps", "v1", "pods"):                                verbsAll,
+			NewResourceRequirement("apps", "v1", "pods/exec"):                           verbsAll,
+			NewResourceRequirement("apps", "v1", "pods/log"):                            verbsAll,
+			NewResourceRequirement("apps", "v1", "secrets"):                             verbsAll,
+			NewResourceRequirement("apps", "v1", "services"):                            verbsAll,
+			NewResourceRequirement("metrics.k8s.io", "v1beta1", "storageclasses"):       verbsGetListWatch,
+			NewResourceRequirement("networking.k8s.io", "v1", "deployments"):            verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "events"):                 verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "persistentvolumeclaims"): verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "pods"):                   verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "pods/exec"):              verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "pods/log"):               verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "secrets"):                verbsAll,
+			NewResourceRequirement("networking.k8s.io", "v1", "services"):               verbsAll,
+			NewResourceRequirement("storage.k8s.io", "v1", "pods"):                      verbsGetListWatch,
 		},
 	},
 }
@@ -39,11 +72,16 @@ type ResourceVerbs []string
 type VersionedResourceRequirements struct {
 	VersionConstraints   *semver.Constraints
 	ResourceRequirements map[*ResourceRequirement]ResourceVerbs
+	// These are only required because the role in the Helm chart specifies broad swathes of permissions that
+	// don't necessarily exist in the real world.
+	RoleOnlyResourceRequirements map[*ResourceRequirement]ResourceVerbs
 }
 
-var verbsCreateDeleteList ResourceVerbs = []string{"create", "delete", "list"}
+var verbsAll ResourceVerbs = []string{"create", "delete", "deletecollection", "get", "list", "update", "patch", "watch"}
+var verbsGetListWatch = []string{"get", "list", "watch"}
+var verbsGetCreate = []string{"get", "create"}
 
-// NewResourceRequirement is just a convenience function for creating ResourceRequirements.
+// NewResourceRequirement is just a convenience function for creating ResourceRequirements for which the resource type must exist.
 func NewResourceRequirement(apiGroup, version, resource string) *ResourceRequirement {
 	return &ResourceRequirement{
 		Group:    apiGroup,

--- a/internal/checks/kube/resources_test.go
+++ b/internal/checks/kube/resources_test.go
@@ -69,6 +69,10 @@ func Test_KubernetesChecker_CheckResources(t *testing.T) {
 					w.WriteHeader(http.StatusOK)
 					err := json.NewEncoder(w).Encode(appsV1ResourceList)
 					assert.Success(t, "failed to encode response", err)
+				case "/apis/metrics.k8s.io/v1":
+					w.WriteHeader(http.StatusOK)
+					err := json.NewEncoder(w).Encode(metricsV1ResourceLilst)
+					assert.Success(t, "failed to encode response", err)
 				case "/apis/networking.k8s.io/v1":
 					w.WriteHeader(http.StatusOK)
 					err := json.NewEncoder(w).Encode(networkingV1ResourceList)
@@ -76,6 +80,10 @@ func Test_KubernetesChecker_CheckResources(t *testing.T) {
 				case "/apis/rbac.authorization.k8s.io/v1":
 					w.WriteHeader(http.StatusOK)
 					err := json.NewEncoder(w).Encode(rbacV1ResourceList)
+					assert.Success(t, "failed to encode response", err)
+				case "/apis/storage.k8s.io/v1":
+					w.WriteHeader(http.StatusOK)
+					err := json.NewEncoder(w).Encode(storageV1ResourceList)
 					assert.Success(t, "failed to encode response", err)
 				default:
 					w.WriteHeader(http.StatusNotFound)
@@ -125,6 +133,15 @@ var fullAPIGroupList *metav1.APIGroupList = &metav1.APIGroupList{
 			},
 		},
 		{
+			Name: "metrics.k8s.io",
+			Versions: []metav1.GroupVersionForDiscovery{
+				{
+					GroupVersion: "metrics.k8s.io/v1beta1",
+					Version:      "v1",
+				},
+			},
+		},
+		{
 			Name: "networking.k8s.io",
 			Versions: []metav1.GroupVersionForDiscovery{
 				{
@@ -142,84 +159,36 @@ var fullAPIGroupList *metav1.APIGroupList = &metav1.APIGroupList{
 				},
 			},
 		},
-	},
-}
-
-var v1ResourceList = &metav1.APIResourceList{
-	TypeMeta: metav1.TypeMeta{
-		Kind: "APIResourceList",
-	},
-	GroupVersion: "v1",
-	APIResources: []metav1.APIResource{
 		{
-			Name:  "pods",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "secrets",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "serviceaccounts",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "services",
-			Verbs: []string{"get"},
+			Name: "storage.k8s.io",
+			Versions: []metav1.GroupVersionForDiscovery{
+				{
+					GroupVersion: "storage.k8s.io/v1",
+					Version:      "v1",
+				},
+			},
 		},
 	},
 }
 
-var appsV1ResourceList = &metav1.APIResourceList{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "APIResourceList",
-		APIVersion: "v1",
-	},
-	GroupVersion: "apps/v1",
-	APIResources: []metav1.APIResource{
-		{
-			Name:  "deployments",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "replicasets",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "statefulsets",
-			Verbs: []string{"get"},
-		},
-	},
-}
+var v1ResourceList = makeResourceList("", "v1", "persistentvolumes", "persistentvolumeclaims", "events", "pods", "secrets", "serviceaccounts", "services")
+var appsV1ResourceList = makeResourceList("v1", "apps/v1", "deployments", "replicasets", "statefulsets")
+var metricsV1ResourceLilst = makeResourceList("v1", "metrics.k8s.io/v1beta1", "pods")
+var networkingV1ResourceList = makeResourceList("v1", "networking.k8s.io/v1", "ingresses", "networkpolicies")
+var rbacV1ResourceList = makeResourceList("v1", "rbac.authorization.k8s.io/v1", "roles", "rolebindings")
+var storageV1ResourceList = makeResourceList("v1", "storage.k8s.io/v1", "roles", "storageclasses")
 
-var networkingV1ResourceList = &metav1.APIResourceList{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "APIResourceList",
-		APIVersion: "v1",
-	},
-	GroupVersion: "networking.k8s.io/v1",
-	APIResources: []metav1.APIResource{
-		{
-			Name:  "ingresses",
-			Verbs: []string{"get"},
+func makeResourceList(version, groupVersion string, resources ...string) *metav1.APIResourceList {
+	rl := &metav1.APIResourceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: version,
 		},
-	},
-}
-
-var rbacV1ResourceList = &metav1.APIResourceList{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "APIResourceList",
-		APIVersion: "v1",
-	},
-	GroupVersion: "rbac.authorization.k8s.io/v1",
-	APIResources: []metav1.APIResource{
-		{
-			Name:  "roles",
-			Verbs: []string{"get"},
-		},
-		{
-			Name:  "rolebindings",
-			Verbs: []string{"get"},
-		},
-	},
+		GroupVersion: groupVersion,
+		APIResources: []metav1.APIResource{},
+	}
+	for _, resource := range resources {
+		rl.APIResources = append(rl.APIResources, metav1.APIResource{Name: resource, Verbs: []string{"get"}})
+	}
+	return rl
 }


### PR DESCRIPTION
This updates the list of ResourceRequirements based on the permissions required to install Coder into a clean KinD cluster.
An initial role/rolebinding/user were created in the cluster, and permissions gradually added to the role until the helm install succeeded.

I ended up needing to break out some of the ResourceRequirements into a separate RoleOnlyResourceRequirements, due to how the role is specified in enterprise-helm. A number of the resources required to create the role don't seem to be things that can exist in the real world (please do correct me if I'm mistaken!)

At this point, running the check is starting to take a while, so I'd say the next step is to look into parallelising the RBAC checks (or using the equivalent API call to `kubectl auth can-i --list`).