### PR TITLE
chore: rbac: speed up tests by using fake k8s Clientset

### DIFF
--- a/internal/checks/kube/rbac_test.go
+++ b/internal/checks/kube/rbac_test.go
@@ -142,7 +142,6 @@ func Test_CheckRBACDefault(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			//assert.Success(t, "failed to create client", err)
 			client := fake.NewSimpleClientset()
 
 			fakeAction := func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {


### PR DESCRIPTION
Turns out that http requests have overhead, who'da thunk