### PR TITLE
chore: rename module from github.com/cdr to cdr.dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cdr/coder-doctor
+module cdr.dev/coder-doctor
 
 go 1.16
 

--- a/internal/api/error_test.go
+++ b/internal/api/error_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestErrorResult(t *testing.T) {

--- a/internal/api/pass_test.go
+++ b/internal/api/pass_test.go
@@ -3,8 +3,8 @@ package api_test
 import (
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestPassResult(t *testing.T) {

--- a/internal/api/skip_test.go
+++ b/internal/api/skip_test.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestSkippedResult(t *testing.T) {

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -3,8 +3,8 @@ package api_test
 import (
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestKnownStates(t *testing.T) {

--- a/internal/api/warn_test.go
+++ b/internal/api/warn_test.go
@@ -3,8 +3,8 @@ package api_test
 import (
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestWarnResult(t *testing.T) {

--- a/internal/api/writer_test.go
+++ b/internal/api/writer_test.go
@@ -3,8 +3,8 @@ package api_test
 import (
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestDiscardWriter(t *testing.T) {

--- a/internal/checks/kube/kubernetes.go
+++ b/internal/checks/kube/kubernetes.go
@@ -11,7 +11,7 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 var _ = api.Checker(&KubernetesChecker{})

--- a/internal/checks/kube/rbac.go
+++ b/internal/checks/kube/rbac.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/internal/checks/kube/rbac_test.go
+++ b/internal/checks/kube/rbac_test.go
@@ -15,7 +15,7 @@ import (
 
 	"cdr.dev/slog/sloggers/slogtest/assert"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 func Test_CheckRBAC_Error(t *testing.T) {

--- a/internal/checks/kube/resources.go
+++ b/internal/checks/kube/resources.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 func (k *KubernetesChecker) CheckResources(_ context.Context) []*api.CheckResult {

--- a/internal/checks/kube/resources_list.go
+++ b/internal/checks/kube/resources_list.go
@@ -3,7 +3,7 @@ package kube
 import (
 	"github.com/Masterminds/semver/v3"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 // This is a list of all known Resource and/or RBAC requirements for each verison of Coder.

--- a/internal/checks/kube/resources_test.go
+++ b/internal/checks/kube/resources_test.go
@@ -11,8 +11,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func Test_KubernetesChecker_CheckResources(t *testing.T) {

--- a/internal/checks/kube/version.go
+++ b/internal/checks/kube/version.go
@@ -10,7 +10,7 @@ import (
 
 	"cdr.dev/slog"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 type CoderVersionRequirement struct {

--- a/internal/checks/kube/version_test.go
+++ b/internal/checks/kube/version_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func TestVersions(t *testing.T) {

--- a/internal/checks/local/helm.go
+++ b/internal/checks/local/helm.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 const LocalHelmVersionCheck = "local-helm-version"

--- a/internal/checks/local/helm_test.go
+++ b/internal/checks/local/helm_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 
+	"cdr.dev/coder-doctor/internal/api"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
 )
 
 func Test_CheckLocalHelmVersion(t *testing.T) {

--- a/internal/checks/local/local.go
+++ b/internal/checks/local/local.go
@@ -11,7 +11,7 @@ import (
 	"cdr.dev/slog"
 	"cdr.dev/slog/sloggers/sloghuman"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 var _ api.Checker = &Checker{}

--- a/internal/cmd/check/check.go
+++ b/internal/cmd/check/check.go
@@ -3,7 +3,7 @@ package check
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/cdr/coder-doctor/internal/cmd/check/kubernetes"
+	"cdr.dev/coder-doctor/internal/cmd/check/kubernetes"
 )
 
 func NewCommand() *cobra.Command {

--- a/internal/cmd/check/kubernetes/kubernetes.go
+++ b/internal/cmd/check/kubernetes/kubernetes.go
@@ -20,10 +20,10 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/cdr/coder-doctor/internal/api"
-	"github.com/cdr/coder-doctor/internal/checks/kube"
-	"github.com/cdr/coder-doctor/internal/checks/local"
-	"github.com/cdr/coder-doctor/internal/humanwriter"
+	"cdr.dev/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/checks/kube"
+	"cdr.dev/coder-doctor/internal/checks/local"
+	"cdr.dev/coder-doctor/internal/humanwriter"
 )
 
 func NewCommand() *cobra.Command {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/cdr/coder-doctor/internal/cmd/check"
-	"github.com/cdr/coder-doctor/internal/cmd/version"
+	"cdr.dev/coder-doctor/internal/cmd/check"
+	"cdr.dev/coder-doctor/internal/cmd/version"
 )
 
 func NewDefaultDoctorCommand() *cobra.Command {

--- a/internal/filterwriter/filter.go
+++ b/internal/filterwriter/filter.go
@@ -1,7 +1,7 @@
 package filterwriter
 
 import (
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 var _ = api.ResultWriter(&FilterWriter{})

--- a/internal/filterwriter/filter_test.go
+++ b/internal/filterwriter/filter_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/filterwriter"
+	"cdr.dev/coder-doctor/internal/humanwriter"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
-	"github.com/cdr/coder-doctor/internal/filterwriter"
-	"github.com/cdr/coder-doctor/internal/humanwriter"
 )
 
 func TestFilter(t *testing.T) {

--- a/internal/humanwriter/human.go
+++ b/internal/humanwriter/human.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 var _ = api.ResultWriter(&HumanResultWriter{})

--- a/internal/humanwriter/human_test.go
+++ b/internal/humanwriter/human_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/humanwriter"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
-	"github.com/cdr/coder-doctor/internal/humanwriter"
 )
 
 func TestHumanWriter(t *testing.T) {

--- a/internal/jsonwriter/json.go
+++ b/internal/jsonwriter/json.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/cdr/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/api"
 )
 
 var _ = api.ResultWriter(&JSONWriter{})

--- a/internal/jsonwriter/json_test.go
+++ b/internal/jsonwriter/json_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/jsonwriter"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
-	"github.com/cdr/coder-doctor/internal/jsonwriter"
 )
 
 func TestJSONWriter(t *testing.T) {

--- a/internal/summarywriter/summary.go
+++ b/internal/summarywriter/summary.go
@@ -1,6 +1,6 @@
 package summarywriter
 
-import "github.com/cdr/coder-doctor/internal/api"
+import "cdr.dev/coder-doctor/internal/api"
 
 type SummaryResult struct {
 	Passed  int `json:"passed"`

--- a/internal/summarywriter/summary_test.go
+++ b/internal/summarywriter/summary_test.go
@@ -3,9 +3,9 @@ package summarywriter_test
 import (
 	"testing"
 
+	"cdr.dev/coder-doctor/internal/api"
+	"cdr.dev/coder-doctor/internal/summarywriter"
 	"cdr.dev/slog/sloggers/slogtest/assert"
-	"github.com/cdr/coder-doctor/internal/api"
-	"github.com/cdr/coder-doctor/internal/summarywriter"
 )
 
 func TestSummaryWriter(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cdr/coder-doctor/internal/cmd"
+	"cdr.dev/coder-doctor/internal/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Use our vanity URL for our module name.