### PR TITLE
chore: improve text output for resource check

### DIFF
--- a/internal/checks/kube/resources_test.go
+++ b/internal/checks/kube/resources_test.go
@@ -29,6 +29,8 @@ func Test_KubernetesChecker_CheckResources(t *testing.T) {
 			F: func(t *testing.T, results []*api.CheckResult) {
 				assert.False(t, "results should not be empty", len(results) == 0)
 				for _, result := range results {
+					assert.False(t, result.Name+" should have a resource", len(result.Details["resource"].(string)) == 0)
+					assert.False(t, result.Name+" should have a groupVersion", len(result.Details["groupVersion"].(string)) == 0)
 					assert.Equal(t, result.Name+" should have no error", nil, result.Details["error"])
 					assert.Equal(t, result.Name+" should pass", api.StatePassed, result.State)
 				}
@@ -40,10 +42,10 @@ func Test_KubernetesChecker_CheckResources(t *testing.T) {
 			F: func(t *testing.T, results []*api.CheckResult) {
 				assert.False(t, "results should not be empty", len(results) == 0)
 				for _, result := range results {
-					resErr, ok := result.Details["error"].(error)
-					assert.True(t, result.Name+" should have an error", ok && resErr != nil)
-					assert.ErrorContains(t, result.Name+" should have an expected error", resErr, "missing required resource")
-					assert.True(t, result.Name+" should fail", result.State == api.StateFailed)
+					assert.False(t, result.Name+" should have a resource", len(result.Details["resource"].(string)) == 0)
+					assert.False(t, result.Name+" should have a groupVersion", len(result.Details["groupVersion"].(string)) == 0)
+					assert.Equal(t, result.Name+" should have no error", nil, result.Details["error"])
+					assert.Equal(t, result.Name+" should pass", api.StateFailed, result.State)
 				}
 			},
 		},


### PR DESCRIPTION
* Remove the synthetic error and create a failed result manually
* Add the resource, group, and groupVersion in Details, so that
  it will be included in JSON output

Output before:

```shell-session
$ go run . check kubernetes
🔔 kube context: "gke_coder-dev-1_us-central1-a_dev-4"
✓ Coder 1.21.0 supports Helm >=3.6.0
✓ Coder 1.21.0 supports Kubernetes 1.19.0 to 1.22.0 (server version 1.20.9-gke.701)
✓ found required resource:"persistentvolumeclaims" group:"" version:"v1"
✓ found required resource:"services" group:"" version:"v1"
✓ found required resource:"pods" group:"metrics.k8s.io" version:"metrics.k8s.io/v1beta1"
✓ found required resource:"serviceaccounts" group:"" version:"v1"
✓ found required resource:"deployments" group:"apps" version:"apps/v1"
✓ found required resource:"statefulsets" group:"apps" version:"apps/v1"
✓ found required resource:"roles" group:"rbac.authorization.k8s.io" version:"rbac.authorization.k8s.io/v1"
✓ found required resource:"events" group:"" version:"v1"
✓ found required resource:"pods" group:"" version:"v1"
✓ found required resource:"secrets" group:"" version:"v1"
✓ found required resource:"replicasets" group:"apps" version:"apps/v1"
✓ found required resource:"ingresses" group:"networking.k8s.io" version:"networking.k8s.io/v1"
✓ found required resource:"networkpolicies" group:"networking.k8s.io" version:"networking.k8s.io/v1"
✓ found required resource:"rolebindings" group:"rbac.authorization.k8s.io" version:"rbac.authorization.k8s.io/v1"
✓ found required resource:"storageclasses" group:"storage.k8s.io" version:"storage.k8s.io/v1"
```

Output after:

```shell-session
$ go run . check kubernetes
🔔 kube context: "gke_coder-dev-1_us-central1-a_dev-4"
✓ Coder 1.21.0 supports Helm >=3.6.0
✓ Coder 1.21.0 supports Kubernetes 1.19.0 to 1.22.0 (server version 1.20.9-gke.701)
✓ Cluster supports v1 resource serviceaccounts
✓ Cluster supports apps/v1 resource replicasets
✓ Cluster supports v1 resource persistentvolumeclaims
✓ Cluster supports v1 resource services
✓ Cluster supports apps/v1 resource statefulsets
✓ Cluster supports networking.k8s.io/v1 resource ingresses
✓ Cluster supports rbac.authorization.k8s.io/v1 resource rolebindings
✓ Cluster supports v1 resource pods
✓ Cluster supports v1 resource secrets
✓ Cluster supports apps/v1 resource deployments
✓ Cluster supports metrics.k8s.io/v1beta1 resource pods
✓ Cluster supports v1 resource events
✓ Cluster supports networking.k8s.io/v1 resource networkpolicies
✓ Cluster supports rbac.authorization.k8s.io/v1 resource roles
✓ Cluster supports storage.k8s.io/v1 resource storageclasses
```